### PR TITLE
fix chat page header

### DIFF
--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,5 +1,5 @@
 <h1>
-Chat with <%= link_to @user.email, user_profile_path(current_user.id) %>
+Chat with <%= link_to @user.first_name, user_profile_path(@user.id) %>
 </h1>
 <span id="channel" style="display:none;" data-channel="<%= @channel %>"></span>
 <div>


### PR DESCRIPTION
change email on top of chat page to first name and fix link so it properly sends user to profile page of the person the user is chatting with.

![image](https://user-images.githubusercontent.com/40725104/46931426-14693880-d019-11e8-9776-8351a6bf2f99.png)
