### PR TITLE
Remove map from navbar

### DIFF
--- a/app/assets/stylesheets/listings.css
+++ b/app/assets/stylesheets/listings.css
@@ -58,3 +58,11 @@
 .approval-message {
   display: flex;
 }
+
+.table.td {
+  vertical-align: baseline;
+}
+
+.btn-primary.btn {
+  margin: 0;
+}

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -4,13 +4,13 @@
   <table class='table listings-table table-striped'>
     <tbody>
       <tr>
-        <th class='row-name'scope='row'>Moving From:</th>
+        <th class='row-name'scope='row'>Pick Up:</th>
         <td class='row-data'>
           <a href='http://maps.google.com/maps?q=<%= @listing.latitude %>,<%= @listing.longitude %>'><%= @listing.address %></a>
         </td>
       </tr>
       <tr>
-        <th class='row-name 'scope='row'>Moving To:</th>
+        <th class='row-name 'scope='row'>Drop Off:</th>
         <td class='row-data '><%= @listing.ending_address %></td>
       </tr>
       <tr>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -1,5 +1,5 @@
 <div class='show-page'>
-  <h1><strong><%= @listing.description %></strong></h1>
+  <h1><strong><%= @listing.city %>, <%= @listing.state %> to <%= @listing.ending_address %></strong></h1>
 
   <table class='table listings-table table-striped'>
     <tbody>
@@ -45,9 +45,13 @@
         <td class='row-data '><%= @listing.max_people %></td>
       </tr>
       <tr>
+        <th class='row-name '>Additional Information:</th>
+        <td class='row-data '><%= @listing.description %></td>
+      </tr>
+      <tr>
         <th class='row-name' scope='row'>Contact:</th>
         <td class='row-data'>
-          <%= link_to "Send a message", user_messages_path(@listing.user_id), class:'btn btn-light' %>
+          <%= link_to "Send a message", user_messages_path(@listing.user_id), class:'btn btn-info' %>
         </td>
       </tr>
     </tbody>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,5 +1,5 @@
 <h1>
-Chat with <%= link_to @user.email, user_profile_path(current_user.id) %>
+Chat with <%= link_to @user.first_name, user_profile_path(@user.id) %>
 </h1>
 <span id="channel" style="display:none;" data-channel="<%= @channel %>"></span>
 <div>

--- a/app/views/static_pages/_navbar.html.erb
+++ b/app/views/static_pages/_navbar.html.erb
@@ -14,9 +14,6 @@
       <li class='nav-item'>
         <%= link_to 'Move', new_listing_path, class: 'nav-link' %>
       </li>
-      <li class='nav-item'>
-        <%= link_to 'Map', map_path, class: 'nav-link' %>
-      </li>
     </ul>
 
     <% if user_signed_in? %>


### PR DESCRIPTION
the map link is redundant since the map is being displayed on the listings page

![image](https://user-images.githubusercontent.com/40725104/46932512-15e92f80-d01e-11e8-8950-6011e6dfc1b0.png)
