### PR TITLE
Enhancement 202 pio sticky nav

### DIFF
--- a/app/assets/stylesheets/listings.css
+++ b/app/assets/stylesheets/listings.css
@@ -1,4 +1,4 @@
-.show-page {
+/* .show-page {
   position: fixed;
   overflow: auto;
   height: 100%;
@@ -25,7 +25,7 @@
   	);
   background-blend-mode: screen;
   font-family: 'Maven Pro', sans-serif;
-}
+} */
 
 .row-data a {
   color: inherit;


### PR DESCRIPTION
closes #202 

I commented out some styling on the show page. The position: absolute css was causing the entire page to go behind the footer. What I commented out didn't make a big difference visually - please check this change before review - footer looks very nice and works on all pages.

<img width="1542" alt="screen shot 2018-10-14 at 10 40 36 pm" src="https://user-images.githubusercontent.com/41122916/46933753-5f884900-d023-11e8-8b7b-f965e9406a9b.png">
